### PR TITLE
fixes typo: exported CobraCommand for SysShareProxyClient

### DIFF
--- a/pkg/service_proxy.go
+++ b/pkg/service_proxy.go
@@ -33,7 +33,7 @@ func NewSysShareProxyClient() *SysShareProxyClient {
 }
 
 // Easy access to create CLI
-func (s *SysShareProxyClient) cobraCommand() *cobra.Command {
+func (s *SysShareProxyClient) CobraCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "sys-share proxy client",
 		Short: "sys-share proxy client cli",


### PR DESCRIPTION
Export CobraCommand for SysShareProxyClient: a typo of smallcase.