### PR TITLE
sys-share added proxy for client-side library (go)

### DIFF
--- a/sys-account/service/go/pkg/auth_model.go
+++ b/sys-account/service/go/pkg/auth_model.go
@@ -110,6 +110,15 @@ type ForgotPasswordResponse struct {
 	ForgotPasswordRequestedAt int64  `json:"forgotPasswordRequestedAt,omitempty"`
 }
 
+func ForgotPasswordResponseFromProto(in *authRpc.ForgotPasswordResponse) *ForgotPasswordResponse {
+	return &ForgotPasswordResponse{
+		Success:                   in.Success,
+		SuccessMsg:                in.SuccessMsg,
+		ErrorReason:               in.ErrorReason.Reason,
+		ForgotPasswordRequestedAt: tsToUnixUTC(in.ForgotPasswordRequestedAt),
+	}
+}
+
 func (fpres *ForgotPasswordResponse) ToProto() *authRpc.ForgotPasswordResponse {
 	return &authRpc.ForgotPasswordResponse{
 		Success:                   fpres.Success,
@@ -140,6 +149,15 @@ type ResetPasswordResponse struct {
 	ResetPasswordRequestedAt int64  `json:"resetPasswordRequestedAt,omitempty"`
 }
 
+func ResetPasswordResponseFromProto(in *authRpc.ResetPasswordResponse) *ResetPasswordResponse {
+	return &ResetPasswordResponse{
+		Success:                  in.Success,
+		SuccessMsg:               in.SuccessMsg,
+		ErrorReason:              in.GetErrorReason().Reason,
+		ResetPasswordRequestedAt: tsToUnixUTC(in.ResetPasswordRequestedAt),
+	}
+}
+
 func (rps *ResetPasswordResponse) ToProto() *authRpc.ResetPasswordResponse {
 	return &authRpc.ResetPasswordResponse{
 		Success:                  rps.Success,
@@ -166,5 +184,12 @@ func (ratr *RefreshAccessTokenResponse) ToProto() *authRpc.RefreshAccessTokenRes
 	return &authRpc.RefreshAccessTokenResponse{
 		AccessToken: ratr.AccessToken,
 		ErrorReason: &authRpc.ErrorReason{Reason: ratr.ErrorReason},
+	}
+}
+
+func RefreshAccessTokenFromProto(in *authRpc.RefreshAccessTokenResponse) *RefreshAccessTokenResponse {
+	return &RefreshAccessTokenResponse{
+		AccessToken: in.AccessToken,
+		ErrorReason: in.GetErrorReason().GetReason(),
 	}
 }

--- a/sys-account/service/go/pkg/service_proxy.go
+++ b/sys-account/service/go/pkg/service_proxy.go
@@ -29,6 +29,20 @@ func (s *SysAccountProxyService) RegisterSvc(server *grpc.Server) {
 	reflection.Register(server)
 }
 
+// this one for Client (non CLI)
+type SysAccountProxyServiceClient struct {
+	*accountSvcClientProxy
+	*authSvcClientProxy
+}
+
+func NewSysAccountProxyServiceClient(cc grpc.ClientConnInterface) *SysAccountProxyServiceClient {
+	return &SysAccountProxyServiceClient{
+		newAccountSvcClientProxy(cc),
+		newAuthSvcClientProxy(cc),
+	}
+}
+
+// this one for CLI
 type SysAccountProxyClient struct {
 	SysAccountClient *sysAccountClient
 }

--- a/sys-account/service/go/pkg/sys_account_proxy.go
+++ b/sys-account/service/go/pkg/sys_account_proxy.go
@@ -253,3 +253,144 @@ func newAuthService(au AuthService) *authService {
 func (au *authService) registerSvc(server *grpc.Server) {
 	rpc.RegisterAuthServiceService(server, au.svc)
 }
+
+type AccountServiceClient interface {
+	NewAccount(ctx context.Context, in *Account, opts ...grpc.CallOption) (*Account, error)
+	GetAccount(ctx context.Context, in *GetAccountRequest, opts ...grpc.CallOption) (*Account, error)
+	ListAccounts(ctx context.Context, in *ListAccountsRequest, opts ...grpc.CallOption) (*ListAccountsResponse, error)
+	SearchAccounts(ctx context.Context, in *SearchAccountsRequest, opts ...grpc.CallOption) (*SearchAccountsResponse, error)
+	AssignAccountToRole(ctx context.Context, in *AssignAccountToRoleRequest, opts ...grpc.CallOption) (*Account, error)
+	UpdateAccount(ctx context.Context, in *Account, opts ...grpc.CallOption) (*Account, error)
+	DisableAccount(ctx context.Context, in *DisableAccountRequest, opts ...grpc.CallOption) (*Account, error)
+}
+
+type accountSvcClientProxy struct {
+	svcClient rpc.AccountServiceClient
+}
+
+func newAccountSvcClientProxy(cc grpc.ClientConnInterface) *accountSvcClientProxy {
+	newClient := rpc.NewAccountServiceClient(cc)
+	return &accountSvcClientProxy{svcClient: newClient}
+}
+
+func (as *accountSvcClientProxy) NewAccount(ctx context.Context, in *Account, opts ...grpc.CallOption) (*Account, error) {
+	acc, err := in.ToProto()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := as.svcClient.NewAccount(ctx, acc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return AccountFromProto(resp), nil
+}
+
+func (as *accountSvcClientProxy) GetAccount(ctx context.Context, in *GetAccountRequest, opts ...grpc.CallOption) (*Account, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.GetAccount(ctx, req, opts...)
+	if err != nil { return nil, err }
+	return AccountFromProto(resp), nil
+}
+
+func (as *accountSvcClientProxy) ListAccounts(ctx context.Context, in *ListAccountsRequest, opts ...grpc.CallOption) (*ListAccountsResponse, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.ListAccounts(ctx, req, opts...)
+	if err != nil { return nil, err}
+	return ListAccountsResponseFromProto(resp), nil
+}
+
+func (as *accountSvcClientProxy) SearchAccounts(ctx context.Context, in *SearchAccountsRequest, opts ...grpc.CallOption) (*SearchAccountsResponse, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.SearchAccounts(ctx, req, opts...)
+	if err != nil { return nil, err}
+	return SearchAccountResponseFromProto(resp), nil
+}
+
+func (as *accountSvcClientProxy) AssignAccountToRole(ctx context.Context, in *AssignAccountToRoleRequest, opts ...grpc.CallOption) (*Account, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.AssignAccountToRole(ctx, req, opts...)
+	if err != nil { return nil, err}
+	return AccountFromProto(resp), nil
+}
+
+func (as *accountSvcClientProxy) UpdateAccount(ctx context.Context, in *Account, opts ...grpc.CallOption) (*Account, error) {
+	req, err := in.ToProto()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := as.svcClient.UpdateAccount(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return AccountFromProto(resp), nil
+}
+
+func (as *accountSvcClientProxy) DisableAccount(ctx context.Context, in *DisableAccountRequest, opts ...grpc.CallOption) (*Account, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.DisableAccount(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return AccountFromProto(resp), nil
+}
+
+
+type AuthServiceClient interface {
+	Register(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (*RegisterResponse, error)
+	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
+	ForgotPassword(ctx context.Context, in *ForgotPasswordRequest, opts ...grpc.CallOption) (*ForgotPasswordResponse, error)
+	ResetPassword(ctx context.Context, in *ResetPasswordRequest, opts ...grpc.CallOption) (*ResetPasswordResponse, error)
+	RefreshAccessToken(ctx context.Context, in *RefreshAccessTokenRequest, opts ...grpc.CallOption) (*RefreshAccessTokenResponse, error)
+}
+
+type authSvcClientProxy struct {
+	svcClient rpc.AuthServiceClient
+}
+
+func newAuthSvcClientProxy(cc grpc.ClientConnInterface) *authSvcClientProxy {
+	newClient := rpc.NewAuthServiceClient(cc)
+	return &authSvcClientProxy{svcClient: newClient}
+}
+
+func (as *authSvcClientProxy) Register(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (*RegisterResponse, error) {
+	req := in.ToProto()
+	resp,err := as.svcClient.Register(ctx, req, opts...)
+	if err != nil { return nil, err }
+	return RegisterResponseFromProto(resp), nil
+}
+
+func (as *authSvcClientProxy) Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.Login(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return LoginResponseFromProto(resp), nil
+}
+
+func (as *authSvcClientProxy) ForgotPassword(ctx context.Context, in *ForgotPasswordRequest, opts ...grpc.CallOption) (*ForgotPasswordResponse, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.ForgotPassword(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return ForgotPasswordResponseFromProto(resp), nil
+}
+
+func (as *authSvcClientProxy) ResetPassword(ctx context.Context, in *ResetPasswordRequest, opts ...grpc.CallOption) (*ResetPasswordResponse, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.ResetPassword(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return ResetPasswordResponseFromProto(resp), nil
+}
+
+func (as *authSvcClientProxy) RefreshAccessToken(ctx context.Context, in *RefreshAccessTokenRequest, opts ...grpc.CallOption) (*RefreshAccessTokenResponse, error) {
+	req := in.ToProto()
+	resp, err := as.svcClient.RefreshAccessToken(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return RefreshAccessTokenFromProto(resp), nil
+}


### PR DESCRIPTION
In order for me to complete: https://github.com/getcouragenow/main/issues/7 and server side mod-dummy as defined in https://github.com/getcouragenow/shared/blob/master/doc/roadmap/mixin-jsonnet.md#roadmap

Especially point number 3, 4, and 5 (of mod-dummy) i need this to be merged for now. This basically lets all client be it either cli or ones calling it as a library (grpc call / internal call) do their business. 

Next in line would be client-side auth interceptor (for service to service communication via grpc), not sure where to put it though, should it be on sys or sys-share? or should the auth interceptor be done later (bypassed for now)? if it is to be done later, then we're all set after this, just need one more PR for both mod and main basically. 

Once that is decided then wiring up v3 is going to be a walk in the park, basically.